### PR TITLE
add missing escaping the slashes which are used as separators

### DIFF
--- a/Archive.php
+++ b/Archive.php
@@ -567,7 +567,7 @@ class PHP_Archive
             return '';
         }
         $std = str_replace("\\", "/", $path);
-        while ($std != ($std = preg_replace("/[^\/:?]+/\.\.//", "", $std))) ;
+        while ($std != ($std = preg_replace("/[^\/:?]+\/\.\.\//", "", $std))) ;
         $std = str_replace("/./", "", $std);
         if (strlen($std) > 1 && $std[0] == '/') {
             $std = substr($std, 1);

--- a/Archive/Creator.php
+++ b/Archive/Creator.php
@@ -111,7 +111,7 @@ class PHP_Archive_Creator
             return '';
         }
         $std = str_replace("\\", "/", $path);
-        while ($std != ($std = preg_replace("/[^\/:?]+/\.\.//", "", $std)));
+        while ($std != ($std = preg_replace("/[^\/:?]+\/\.\.\//", "", $std)));
         $std = str_replace("/./", "", $std);
         if (strlen($std) > 1 && $std[0] == '/') {
             $std = substr($std, 1);


### PR DESCRIPTION
after installing the package with this fix I was able to run make-installpear-nozlib-phar.php from the pear-core repository to create a php7 compatible install-pear-nozlib.phar file.