### PR TITLE
Private methods cannot be final

### DIFF
--- a/Archive.php
+++ b/Archive.php
@@ -332,7 +332,7 @@ class PHP_Archive
      * @param string $buffer stub past '__HALT_'.'COMPILER();'
      * @return end of stub, prior to length of manifest.
      */
-    private static final function _endOfStubLength($buffer)
+    private static function _endOfStubLength($buffer)
     {
         $pos = 0;
         if (!strlen($buffer)) {


### PR DESCRIPTION
As of PHP 8.1.0, this combination raises a warning.

This has been reported as <https://github.com/php/php-src/issues/7966>.